### PR TITLE
Add more keyword parsing

### DIFF
--- a/rockstarpy/transpile.py
+++ b/rockstarpy/transpile.py
@@ -60,6 +60,10 @@ class Transpiler(object):
             " is as weak as ": " <= ",
             " is not ": " != ",
             " aint ": " != ",
+            " isnt ": " != ",
+            "empty": '""',
+            "silence": '""',
+            "silent": '""',
             "Until ": "while not ",
             "While ": "while ",
         }
@@ -120,7 +124,7 @@ class Transpiler(object):
     def find_poetic_number_literal(self, line):
         poetic_type_literals_keywords = ["True", "False"]
         match = re.match(
-            r"\b({0})(?: is|\'s| was| were) ([\d\w\.,\:\!\;\'\-\s]+)".format(
+            r"\b({0})(?: is|\'s| was| were| are) ([\d\w\.,\:\!\;\'\-\s]+)".format(
                 self.REGEX_VARIABLES
             ),
             line,
@@ -153,6 +157,24 @@ class Transpiler(object):
         match = re.match(r"([A-Za-z]+(?:_[A-Za-z]+)*) [+-]?= .+", line)
         if match:
             return match.group(1)
+
+    def find_cast(self, line):
+        match = re.match(r"(?:Cast|Burn) (.*) into (.*)", line)
+        if match:
+            line = match.group(2) + " = chr(" + match.group(1) + ")"
+        return line
+
+    def find_split(self, line):
+        match = re.match(r"(?:Cut|Split|Shatter) (.*) into (.*)", line)
+        if match:
+            line = match.group(2) + " = list(" + match.group(1) + ")"
+        return line
+
+    def find_pop(self, line):
+        match = re.match(r"Roll (.*) into (.*)", line)
+        if match:
+            line = match.group(2) + " = " + match.group(1) + ".pop(0)"
+        return line
 
     def get_strings(self, line):
         strings = dict()
@@ -258,6 +280,10 @@ class Transpiler(object):
 
             py_line = self.find_proper_variables(py_line)
             py_line = self.find_common_variables(py_line)
+
+            py_line = self.find_split(py_line)
+            py_line = self.find_cast(py_line)
+            py_line = self.find_pop(py_line)
 
             line_named = self.find_named(py_line)
             if line_named:

--- a/tests/test_assignment.py
+++ b/tests/test_assignment.py
@@ -12,6 +12,11 @@ class TestAssignment(unittest.TestCase):
         py_line = transpiler.transpile_line("Life is ok\n")
         self.assertEqual(py_line, "Life = True\n")
 
+    def test_is_silent(self):
+        transpiler = Transpiler()
+        py_line = transpiler.transpile_line("My music is silent\n")
+        self.assertEqual(py_line, 'my_music = ""\n')
+
     def test_is_poetic(self):
         transpiler = Transpiler()
         py_line = transpiler.transpile_line("My life is a mess\n")

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import unittest
+
+sys.path = [os.path.dirname(os.path.dirname(os.path.realpath(__file__)))] + sys.path
+from rockstarpy.transpile import Transpiler
+
+
+class TestList(unittest.TestCase):
+
+    def test_list(self):
+        transpiler = Transpiler()
+        py_line = transpiler.transpile_line("Shatter a string into a list\n")
+        self.assertEqual(py_line, "a_list = list(a_string)\n")
+    
+    def test_pop(self):
+        transpiler = Transpiler()
+        py_line = transpiler.transpile_line("Roll a list into variable\n")
+        self.assertEqual(py_line, "variable = a_list.pop(0)\n")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add parsing for keywords:  `isnt`, `empty`, `silence`, `silent`, `are`, `cast`, `burn`, `cut`, `split`, `shatter` and `roll` as described in [rock star docs](https://codewithrockstar.com/docs). 

Closes #47.